### PR TITLE
Add arc drawing capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project is an interactive web application for simulating the winding of a s
 
 ## Current State
 
-This repository currently contains an early prototype of the application. Pins can be placed and moved and basic string segments can be drawn between pins. Advanced geometry for wrapping and intersection detection has not yet been implemented.
+This repository currently contains an early prototype of the application. Pins can be placed and moved and basic string segments can be drawn between pins. Simple circular arcs allow the string to wrap around a single pin. Advanced intersection detection has not yet been implemented.
 
 ## Planned Features
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # Development TODO
 
-- [ ] Allow string to wrap around pins with proper arc calculation
+- [x] Allow string to wrap around pins with proper arc calculation
 - [ ] Detect and prevent string intersections
 - [ ] Add color gradient controls for string segments
 - [ ] Implement undo/unwrap functionality

--- a/script.js
+++ b/script.js
@@ -4,7 +4,7 @@ const ctx = canvas.getContext('2d');
 let tool = 'string';
 const pins = [];
 const segments = [];
-let drawing = null;
+let drawing = null; // {start:Pin, endPos:{x,y}, center:Pin|null}
 let draggingPin = null;
 let dragOffset = {x:0,y:0};
 
@@ -37,20 +37,41 @@ function hitPin(pos) {
     return pins.find(p => Math.hypot(p.x - pos.x, p.y - pos.y) <= p.r);
 }
 
+function computeArcParams(start, center, end) {
+    const radius = Math.hypot(start.x - center.x, start.y - center.y);
+    const startAngle = Math.atan2(start.y - center.y, start.x - center.x);
+    const endAngle = Math.atan2(end.y - center.y, end.x - center.x);
+    const cross = (start.x - center.x) * (end.y - center.y) -
+                  (start.y - center.y) * (end.x - center.x);
+    const clockwise = cross < 0;
+    return { radius, startAngle, endAngle, clockwise };
+}
+
 function drawSegments() {
     ctx.strokeStyle = '#000';
     ctx.lineWidth = 2;
     for (const seg of segments) {
         ctx.beginPath();
-        ctx.moveTo(seg.start.x, seg.start.y);
-        ctx.lineTo(seg.end.x, seg.end.y);
+        if (seg.type === 'arc') {
+            ctx.arc(seg.center.x, seg.center.y, seg.radius,
+                seg.startAngle, seg.endAngle, seg.clockwise);
+        } else {
+            ctx.moveTo(seg.start.x, seg.start.y);
+            ctx.lineTo(seg.end.x, seg.end.y);
+        }
         ctx.stroke();
     }
     if (drawing) {
         ctx.setLineDash([5, 5]);
         ctx.beginPath();
-        ctx.moveTo(drawing.start.x, drawing.start.y);
-        ctx.lineTo(drawing.endPos.x, drawing.endPos.y);
+        if (drawing.center) {
+            const tmp = computeArcParams(drawing.start, drawing.center, drawing.endPos);
+            ctx.arc(drawing.center.x, drawing.center.y, tmp.radius,
+                tmp.startAngle, tmp.endAngle, tmp.clockwise);
+        } else {
+            ctx.moveTo(drawing.start.x, drawing.start.y);
+            ctx.lineTo(drawing.endPos.x, drawing.endPos.y);
+        }
         ctx.stroke();
         ctx.setLineDash([]);
     }
@@ -60,11 +81,19 @@ function drawPins() {
     for (const p of pins) {
         ctx.beginPath();
         ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
-        ctx.fillStyle = '#333';
+        if (drawing && drawing.center === p) {
+            ctx.fillStyle = 'orange';
+        } else {
+            ctx.fillStyle = '#333';
+        }
         ctx.fill();
         ctx.strokeStyle = '#fff';
         ctx.lineWidth = 2;
         ctx.stroke();
+        if (drawing && drawing.center === p) {
+            ctx.fillStyle = 'black';
+            ctx.fillText('Arc', p.x + p.r + 4, p.y - p.r - 4);
+        }
     }
 }
 
@@ -79,7 +108,7 @@ canvas.addEventListener('mousedown', (e) => {
     if (tool === 'string') {
         const hit = hitPin(pos);
         if (hit) {
-            drawing = {start: hit, endPos: pos};
+            drawing = {start: hit, endPos: pos, center: null};
         }
     } else if (tool === 'pin') {
         // check for existing pin
@@ -108,6 +137,12 @@ canvas.addEventListener('mousemove', (e) => {
         draw();
     } else if (drawing) {
         drawing.endPos = pos;
+        const center = hitPin(pos);
+        if (center && center !== drawing.start) {
+            drawing.center = center;
+        } else {
+            drawing.center = null;
+        }
         draw();
     }
 });
@@ -116,8 +151,20 @@ canvas.addEventListener('mouseup', (e) => {
     const pos = {x: e.offsetX, y: e.offsetY};
     if (drawing) {
         const hit = hitPin(pos);
-        if (hit && hit !== drawing.start) {
-            segments.push({start: drawing.start, end: hit});
+        if (drawing.center && hit && hit !== drawing.start && hit !== drawing.center) {
+            const arc = computeArcParams(drawing.start, drawing.center, hit);
+            segments.push({
+                type: 'arc',
+                start: drawing.start,
+                end: hit,
+                center: drawing.center,
+                radius: arc.radius,
+                startAngle: arc.startAngle,
+                endAngle: arc.endAngle,
+                clockwise: arc.clockwise
+            });
+        } else if (hit && hit !== drawing.start) {
+            segments.push({type: 'line', start: drawing.start, end: hit});
         }
         drawing = null;
         draw();


### PR DESCRIPTION
## Summary
- implement arc segments with center and sweep data
- preview arc while drawing with a temporary highlight
- show active arc target pin in orange with small text
- describe arc support in `README`
- check off TODO item for wrapping around pins

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68633c100d68832aad01570d8070fe78